### PR TITLE
Feature add jq request

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Required styles for nsModal are available in ```src/main/resources/styles/scss/m
 In order for nsModal to work properly, you must included the compiled CSS from this file in
 your application.
 
-### 0.1.2 - 11/20/2013
+### 0.1.3 - 11/20/2013
 
 Initial release.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "neosavvy-javascript-angular-core-development",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "authors": [
         "Neosavvy, Inc."
     ],

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "q": "0.9.7",
         "jquery": "2.0.3",
+        "jQuery.XDomainRequest": "*",
         "angular": "1.2.4",
         "angular-cache": "1.2.0",
         "neosavvy-javascript-core": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosavvy-javascript-angular-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Neosavvy, Inc."
   },

--- a/src/main/resources/library/services/service-extensions.js
+++ b/src/main/resources/library/services/service-extensions.js
@@ -193,10 +193,10 @@ Neosavvy.AngularCore.Services.factory('nsServiceExtensions',
                     } else {
                         var request = {type: params.method, url: params.url};
                         if (params.data) {
-                            request[data] = params.transformRequest ? params.transformRequest(data) : data;
+                            request.data = params.transformRequest ? params.transformRequest(params.data) : params.data;
                         }
-                        var jqXhr = $.ajax(request)
-                            .done(function (data) {
+                        var jqXhr = $.ajax(request);
+                        jqXhr.done(function (data) {
                                 if (params.transformResponse) {
                                     data = params.transformResponse(
                                         jqXhr.responseText);

--- a/src/main/resources/library/services/service-extensions.js
+++ b/src/main/resources/library/services/service-extensions.js
@@ -164,6 +164,51 @@ Neosavvy.AngularCore.Services.factory('nsServiceExtensions',
                     }
 
                     return deferred.promise;
+                },
+                /**
+                 * @ngdoc method
+                 * @name neosavvy.angularcore.services.services:nsServiceExtensions#jqRequest
+                 * @methodOf neosavvy.angularcore.services.services:nsServiceExtensions
+                 *
+                 * @description
+                 * ThejQuery xDomain supporting request method helper with error handling, transformers, and added response handlers.
+                 *
+                 * @param {Object} params all service params
+                 * @returns {Promise} Q promise object
+                 */
+                jqRequest: function(params) {
+                    if (!params.method) {
+                        throw "You must provide a method for each service request.";
+                    }
+                    if (!params.url) {
+                        throw "You must provide a url for each service request.";
+                    }
+
+                    var deferred = (params.$q) ? $q.defer() : Q.defer();
+
+                    var cached = getFromCache(params);
+                    if (cached) {
+                        //cached[0] is status, cached[1] is response, cached[2] is headers
+                        deferred.resolve(cached[1]);
+                    } else {
+                        var request = {type: params.method, url: params.url};
+                        if (params.data) {
+                            request[data] = params.transformRequest ? params.transformRequest(data) : data;
+                        }
+                        var jqXhr = $.ajax(request)
+                            .done(function (data) {
+                                if (params.transformResponse) {
+                                    data = params.transformResponse(
+                                        jqXhr.responseText);
+                                }
+                                deferred.resolve(data);
+                            })
+                            .fail(function(data) {
+                                deferred.reject(data);
+                            });
+                    }
+
+                    return deferred.promise;
                 }
             };
         }]);

--- a/src/test/resources/library/services/service-extensions-spec.js
+++ b/src/test/resources/library/services/service-extensions-spec.js
@@ -1,4 +1,4 @@
-describe("nsServiceExtensions", function () {
+ddescribe("nsServiceExtensions", function () {
     var extensions, $httpSpy, successMethod, errorMethod, deferredResolveSpy, deferredRejectSpy, additionalSuccessSpy, additionalErrorSpy;
 
     beforeEach(module(function ($provide) {
@@ -29,7 +29,7 @@ describe("nsServiceExtensions", function () {
     }));
 
     beforeEach(function () {
-        module.apply(module, ['neosavvy.angularcore.services']);
+        module('neosavvy.angularcore.services');
 
         inject(function ($injector) {
             extensions = $injector.get('nsServiceExtensions');
@@ -112,17 +112,17 @@ describe("nsServiceExtensions", function () {
             qSpy = spyOn(Q, 'defer').andReturn({promise: "This is my promise!", resolve: deferredResolveSpy, reject: deferredRejectSpy});
             cacheSpy = jasmine.createSpyObj('cacheSpy', ['get', 'put']);
             cacheSpy.get = cacheSpy.get.andReturn(["Status", "My response text", "Headers"]);
-            window.XMLHttpRequest = function() {
+            window.XMLHttpRequest = function () {
                 this.open = jasmine.createSpy();
                 this.send = jasmine.createSpy();
                 this.readyState = 4;
                 myXhrRequest = this;
             };
             window.XMLHttpRequest.prototype = {
-                getAllResponseHeaders: function() {
+                getAllResponseHeaders: function () {
                     "This is your header fool!";
                 },
-                getResponseHeader: function() {
+                getResponseHeader: function () {
                     return 'application/json';
                 }
             };
@@ -197,7 +197,7 @@ describe("nsServiceExtensions", function () {
         });
 
         it("Should parse the response via json if the application response is json", function () {
-            myXhrRequest.getResponseHeader = function() {
+            myXhrRequest.getResponseHeader = function () {
                 return 'application/json';
             };
             var jsonSpy = spyOn(JSON, 'parse');
@@ -215,11 +215,11 @@ describe("nsServiceExtensions", function () {
             myXhrRequest.responseText = '{"name":"Here is your response fool!"}';
             myXhrRequest.status = 200;
             myXhrRequest.onreadystatechange();
-            expect(deferredResolveSpy).toHaveBeenCalledWith({name:"Here is your response fool!"}, 200, undefined);
+            expect(deferredResolveSpy).toHaveBeenCalledWith({name: "Here is your response fool!"}, 200, undefined);
         });
 
         it("Should call the deferred.reject if the status is 200", function () {
-            myXhrRequest.getAllResponseHeaders = function() {
+            myXhrRequest.getAllResponseHeaders = function () {
                 "Here is your header fool!";
             };
             extensions.xhr({method: 'GET', url: 'http://www.neosavvy.co.uk'});
@@ -237,6 +237,56 @@ describe("nsServiceExtensions", function () {
 
         it("Should return the deferred.promise", function () {
             expect(extensions.xhr({method: 'POST', url: 'http://www.google.com/numbers'})).toEqual("This is my promise!");
+        });
+    });
+
+    describe("jqRequest", function () {
+        var qSpy, $qSpy, cacheSpy, deferredResolveSpy, deferredRejectSpy;
+
+        beforeEach(function () {
+            deferredResolveSpy = jasmine.createSpy();
+            deferredRejectSpy = jasmine.createSpy();
+            qSpy = spyOn(Q, 'defer').andReturn({promise: "This is a promise!", resolve: deferredResolveSpy, reject: deferredRejectSpy});
+            cacheSpy = jasmine.createSpyObj('cacheSpy', ['get', 'put']);
+            cacheSpy.get = cacheSpy.get.andReturn(["Status", "My cached response text", "Headers"]);
+            inject(function ($q) {
+                $qSpy = spyOn($q, 'defer').andReturn({promise: "This is a $promise!", resolve: deferredResolveSpy, reject: deferredRejectSpy});
+            });
+        });
+
+        it("Should throw an error when called without a method param", function () {
+            expect(function () {
+                extensions.jqRequest({url: "http://api.github.com"});
+            }).toThrow();
+        });
+
+        it("Should throw an error when called without a url parameter", function () {
+            expect(function () {
+                extensions.jqRequest({method: "GET"});
+            }).toThrow();
+        });
+
+        it("Should call Q.defer in the default case", function () {
+            extensions.jqRequest({method: "GET", url: "http://api.github.com"});
+            expect(qSpy).toHaveBeenCalledWith();
+        });
+
+        it("Should call $q.defer if specified to do so in the params", function () {
+            extensions.jqRequest({method: "GET", url: "http://api.github.com", $q: true});
+            expect($qSpy).toHaveBeenCalledWith();
+        });
+
+        it("Should return the response from the cache if exists for the params", function () {
+            extensions.jqRequest({method: "GET", url: "http://api.github.com", cache: cacheSpy});
+            expect(cacheSpy.get).toHaveBeenCalledWith("http://api.github.com");
+            expect(deferredResolveSpy).toHaveBeenCalledWith("My cached response text");
+        });
+
+        it("Should be able to define a cache and not find anything", function () {
+            cacheSpy.get = cacheSpy.get.andReturn(null);
+            extensions.jqRequest({method: "GET", url: "http://api.github.com", cache: cacheSpy});
+            expect(cacheSpy.get).toHaveBeenCalledWith("http://api.github.com");
+            expect(deferredResolveSpy).not.toHaveBeenCalledWith("My cached response text");
         });
     });
 });


### PR DESCRIPTION
### CHANGE SUMMARY
- Added the jqRequest call to the nsServiceExtensions factory.
- Incremented the bower version to 0.1.3
### CHANGE DETAIL
- The jqRequest method allows angular style service requests to be made using the existing interface with the IE9 supporting jqRequest.
### TEST IMPACT
- New tests for this feature.
- jQuery.XDomainRequest dependency added for IE9 and below.
### DEV IMPACT
- Nothing
### CODE COVERAGE
- Same as it was. nsServiceExtensions needs a bit more, but not in this method.
