### PR TITLE
Bugfix jq request for ie9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Required styles for nsModal are available in ```src/main/resources/styles/scss/m
 In order for nsModal to work properly, you must included the compiled CSS from this file in
 your application.
 
-### 0.1.3 - 11/20/2013
+### 0.1.4 - 11/20/2013
 
 Initial release.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "neosavvy-javascript-angular-core-development",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "authors": [
         "Neosavvy, Inc."
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosavvy-javascript-angular-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Neosavvy, Inc."
   },

--- a/src/main/resources/library/services/service-extensions.js
+++ b/src/main/resources/library/services/service-extensions.js
@@ -184,7 +184,8 @@ Neosavvy.AngularCore.Services.factory('nsServiceExtensions',
                         throw "You must provide a url for each service request.";
                     }
 
-                    var deferred = (params.$q) ? $q.defer() : Q.defer();
+                    //use Angular $q by default, big Q if specified
+                    var deferred = (params.q) ? Q.defer() : $q.defer();
 
                     var cached = getFromCache(params);
                     if (cached) {

--- a/src/main/resources/library/services/service-extensions.js
+++ b/src/main/resources/library/services/service-extensions.js
@@ -195,11 +195,14 @@ Neosavvy.AngularCore.Services.factory('nsServiceExtensions',
                         if (params.data) {
                             request.data = params.transformRequest ? params.transformRequest(params.data) : params.data;
                         }
+                        if (params.ajax) {
+                            request = _.merge(request, params.ajax);
+                        }
                         var jqXhr = $.ajax(request);
                         jqXhr.done(function (data) {
                                 if (params.transformResponse) {
                                     data = params.transformResponse(
-                                        jqXhr.responseText);
+                                        jqXhr.responseText || jqXhr.responseJSON);
                                 }
                                 deferred.resolve(data);
                             })

--- a/src/test/resources/library/services/service-extensions-spec.js
+++ b/src/test/resources/library/services/service-extensions-spec.js
@@ -266,13 +266,13 @@ describe("nsServiceExtensions", function () {
             }).toThrow();
         });
 
-        it("Should call Q.defer in the default case", function () {
-            extensions.jqRequest({method: "GET", url: "http://api.github.com"});
+        it("Should call Q.defer in the specified case", function () {
+            extensions.jqRequest({method: "GET", url: "http://api.github.com", q: true});
             expect(qSpy).toHaveBeenCalledWith();
         });
 
-        it("Should call $q.defer if specified to do so in the params", function () {
-            extensions.jqRequest({method: "GET", url: "http://api.github.com", $q: true});
+        it("Should call $q.defer in the default case", function () {
+            extensions.jqRequest({method: "GET", url: "http://api.github.com"});
             expect($qSpy).toHaveBeenCalledWith();
         });
 
@@ -290,12 +290,12 @@ describe("nsServiceExtensions", function () {
         });
 
         it("Should return the Q promise", function () {
-            var promise = extensions.jqRequest({method: "POST", url: "http://api.github.com"});
+            var promise = extensions.jqRequest({method: "POST", url: "http://api.github.com", q: true});
             expect(promise).toEqual("This is a promise!");
         });
 
         it("Should return the $q promise", function () {
-            var promise = extensions.jqRequest({method: "PUT", url: "http://api.github.com", $q: true});
+            var promise = extensions.jqRequest({method: "PUT", url: "http://api.github.com"});
             expect(promise).toEqual("This is a $promise!");
         });
 


### PR DESCRIPTION
### CHANGE SUMMARY
- Added the customizable ajax param so the requests can take the normal jQuery parameters.
- Fixed an IE9 bug with the jqXhr.responseText property, it uses responseJSON, instead.
### CHANGE DETAIL
- Above.
### TEST IMPACT
- More tests.
### DEV IMPACT
- None, hopefully good.
### CODE COVERAGE
- Same as before, this is entirely covered.
