### PR TITLE
Feature element directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Required styles for nsModal are available in ```src/main/resources/styles/scss/m
 In order for nsModal to work properly, you must included the compiled CSS from this file in
 your application.
 
-### 0.1.5 - 11/20/2013
+### 0.1.6 - 11/20/2013
 
 Initial release.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "neosavvy-javascript-angular-core-development",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "authors": [
         "Neosavvy, Inc."
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosavvy-javascript-angular-core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Neosavvy, Inc."
   },

--- a/src/main/resources/library/directives/data/retrieve-element.js
+++ b/src/main/resources/library/directives/data/retrieve-element.js
@@ -1,0 +1,21 @@
+Neosavvy.AngularCore.Directives
+    .directive('nsRetrieveElement',
+    function () {
+        return {
+            restrict: 'A',
+            scope: false,
+            link: function (scope, element, attrs) {
+                var property = attrs.nsRetrieveElement;
+                if (Neosavvy.Core.Utils.StringUtils.isBlank(attrs.nsRetrieveElement)) {
+                    throw "You must specify a property or function to retrive and element with ns-retrieve-element!";
+                }
+                property = property.replace(/\(.*\)|\(\)/g, "");
+                var prop = Neosavvy.Core.Utils.MapUtils.highPerformanceGet(scope, property);
+                if (typeof prop === "function") {
+                    prop(element);
+                } else {
+                    Neosavvy.Core.Utils.MapUtils.applyTo(scope, property, element);
+                }
+            }
+        }
+    });

--- a/src/test/resources/library/directives/data/retrieve-element-spec.js
+++ b/src/test/resources/library/directives/data/retrieve-element-spec.js
@@ -1,0 +1,69 @@
+ddescribe("nsRetrieveElement", function () {
+    var $rootScope,
+        $scope,
+        $compile,
+        el,
+        localElement,
+        $body = $('body'),
+        simpleHtml = '<input class="my-special-element" ns-retrieve-element="someObject.someProp">',
+        fnAHtml = '<p class="my-fn-special-element" ns-retrieve-element="someOtherFn"></p>',
+        fnBHtml = '<p class="my-fn-special-element" ns-retrieve-element="someOtherFn()"></p>',
+        otherFnHtml = '<p class="my-fn-special-element" ns-retrieve-element="someObject.someFn(element)"></p>';
+
+    beforeEach(function () {
+        module.apply(this, Neosavvy.AngularCore.Dependencies);
+
+        inject(function ($injector, _$compile_) {
+            $rootScope = $injector.get('$rootScope');
+            $scope = $rootScope.$new();
+            $scope.someOtherFn = jasmine.createSpy();
+            $scope.someObject = {
+                someProp: null,
+                someFn: jasmine.createSpy()
+            };
+            $compile = _$compile_;
+            el = $compile(angular.element(simpleHtml))($scope);
+        });
+
+        $body.append(el);
+        $rootScope.$digest();
+    });
+
+    it("Should thow an error if the element is compiled without a property on the nsRetrieveElement", function () {
+        expect(function () {
+            $compile(angular.element('<a ns-retrieve-element>Hello</a>'))($scope);
+        }).toThrow();
+    });
+
+    it("Should throw an error when asked to apply a dot property whose structure does not exist", function () {
+        expect(function () {
+            $compile(angular.element('<a ns-retrieve-element="doesNotExist.otherProperty">Hello</a>'))($scope);
+        }).toThrow();
+    });
+
+    it("Should use a function as a setter when it is not written in function notation", function () {
+        el = $compile(angular.element(fnAHtml))($scope);
+        $body.append(el);
+        expect($scope.someOtherFn).toHaveBeenCalled();
+    });
+
+    it("Should use a function as a setter without any arguments in the param", function () {
+        el = $compile(angular.element(fnBHtml))($scope);
+        $body.append(el);
+        expect($scope.someOtherFn).toHaveBeenCalled();
+    });
+
+    it("Should use a function as a setter with arguments (they are ignored, essentially)", function () {
+        el = $compile(angular.element(otherFnHtml))($scope);
+        $body.append(el);
+        expect($scope.someObject.someFn).toHaveBeenCalled();
+    });
+
+    it("Should be able to set the property on scope", function () {
+        expect($scope.someObject.someProp[0]).toEqual(el[0]);
+    });
+
+    afterEach(function () {
+        $body.empty();
+    });
+});

--- a/src/test/resources/library/directives/data/retrieve-element-spec.js
+++ b/src/test/resources/library/directives/data/retrieve-element-spec.js
@@ -1,4 +1,4 @@
-ddescribe("nsRetrieveElement", function () {
+describe("nsRetrieveElement", function () {
     var $rootScope,
         $scope,
         $compile,


### PR DESCRIPTION
### CHANGE SUMMARY
- Added a directive called nsRetrieveElement so an element can be passed into a scope variable.
- Not an ideal process, but sometimes necessary for quick patches and legacy code.
### CODE COVERAGE
- Same, the jQuery libraries need a little extra.
