### PR TITLE
Feature add tooltip position to modal

### DIFF
--- a/src/main/resources/library/directives/containers/ns-modal.js
+++ b/src/main/resources/library/directives/containers/ns-modal.js
@@ -1,18 +1,32 @@
 Neosavvy.AngularCore.Directives.directive('nsModal', [
     'nsModal',
     function (nsModalService) {
+
+        function positionTooltip (e, element) {
+            var localX = 0.15 * e.currentTarget.clientWidth;
+            var localY = 0.65 * e.currentTarget.clientHeight;
+            var containerCoords = $(e.target).offset();
+            var xPos = localX + containerCoords.left;
+            var yPos = localY + containerCoords.top;
+            element.css("position", "absolute");
+            element.css("top", yPos);
+            element.css("left", xPos);
+            return element;
+        }
+
         return {
-            restrict: 'E',
+            restrict: 'EA',
             transclude: 'element',
             replace: true,
             scope: false,
             compile: function (tElem, tAttr, transclude) {
                 return function (scope, elem, attr) {
-                    var childScope = scope.$new();
+                    var childScope = scope.$new(),
+                        isTooltip = !!attr.tooltip;
 
                     if (typeof attr.open !== 'string') {
                         throw 'an open handler was not specified';
-                    }
+                    };
 
                     // close modal on route change
                     scope.$on('$routeChangeStart', function (e) {
@@ -23,7 +37,8 @@ Neosavvy.AngularCore.Directives.directive('nsModal', [
 
                     scope[attr.open] = function () {
                         transclude(childScope, function (clone) {
-                            nsModalService.open(childScope, clone, closeCallback);
+                            var element = isTooltip ? positionTooltip(e, clone) : clone;
+                            nsModalService.open(childScope, element, closeCallback);
                         });
                     };
 

--- a/src/main/resources/library/directives/containers/ns-modal.js
+++ b/src/main/resources/library/directives/containers/ns-modal.js
@@ -2,8 +2,10 @@ Neosavvy.AngularCore.Directives.directive('nsModal', [
     'nsModal',
     function (nsModalService) {
 
+        // TO DO
+        // make tooltip position customizable
         function positionTooltip (e, element) {
-            var localX = 0.15 * e.currentTarget.clientWidth;
+            var localX = -0.75 * e.currentTarget.clientWidth;
             var localY = 0.65 * e.currentTarget.clientHeight;
             var containerCoords = $(e.target).offset();
             var xPos = localX + containerCoords.left;

--- a/src/main/resources/library/directives/containers/ns-modal.js
+++ b/src/main/resources/library/directives/containers/ns-modal.js
@@ -1,28 +1,35 @@
-Neosavvy.AngularCore.Directives.directive('nsModal', [
-    'nsModal',
-    function (nsModalService) {
+Neosavvy.AngularCore.Directives.controller('nsModalCtrl', ['$scope', function ($scope) {
 
-        // TO DO
-        // make tooltip position customizable
-        function positionTooltip (e, element) {
-            var localX = -0.75 * e.currentTarget.clientWidth;
-            var localY = 0.65 * e.currentTarget.clientHeight;
-            var containerCoords = $(e.target).offset();
-            var xPos = localX + containerCoords.left;
-            var yPos = localY + containerCoords.top;
+    // TO DO
+    // make tooltip position customizable and/or 
+    this.positionTooltip =  function (e, element) {
+            if (e) {
+                var localX = -0.75 * e.currentTarget.clientWidth;
+                var localY = 0.65 * e.currentTarget.clientHeight;
+                var containerCoords = $(e.target).offset();
+                var xPos = localX + containerCoords.left;
+                var yPos = localY + containerCoords.top;
+            }
+            
             element.css("position", "absolute");
             element.css("top", yPos);
             element.css("left", xPos);
             return element;
         }
+}]);
+
+Neosavvy.AngularCore.Directives.directive('nsModal', [
+    'nsModal',
+    function (nsModalService) {
 
         return {
             restrict: 'EA',
             transclude: 'element',
             replace: true,
             scope: false,
+            controller: 'nsModalCtrl',
             compile: function (tElem, tAttr, transclude) {
-                return function (scope, elem, attr) {
+                return function (scope, elem, attr, modalCtrl) {
                     var childScope = scope.$new(),
                         isTooltip = !!attr.tooltip;
 
@@ -37,9 +44,9 @@ Neosavvy.AngularCore.Directives.directive('nsModal', [
 
                     var closeCallback = scope[attr.callback] || angular.noop;
 
-                    scope[attr.open] = function () {
+                    scope[attr.open] = function (e) {
                         transclude(childScope, function (clone) {
-                            var element = isTooltip ? positionTooltip(e, clone) : clone;
+                            var element = isTooltip ? modalCtrl.positionTooltip(e, clone) : clone;
                             nsModalService.open(childScope, element, closeCallback);
                         });
                     };

--- a/src/test/resources/library/directives/containers/ns-modal-spec.js
+++ b/src/test/resources/library/directives/containers/ns-modal-spec.js
@@ -76,11 +76,14 @@ describe('nsModal directive', function () {
     });
 
     describe('nsModalCtrl#isTooltip', function () {
-        var elementSpy;
+        var scope,
+            elementSpy;
 
         beforeEach(function () {
             scope = $rootScope.$new();
+            template = angular.element('<ns-modal tooltip="true" open="openHandler" close="closeHandler">myModal</ns-modal>') 
             controller = $controller('nsModalCtrl', { $scope: scope });
+            $compile(template)(scope);
             scope.$apply();
 
             elementSpy = {
@@ -98,6 +101,11 @@ describe('nsModal directive', function () {
         it('should return the positioned element', function () {
             var res = controller.positionTooltip(undefined, elementSpy);
             expect(res).toEqual(elementSpy);
+        });
+
+        it('should call positionTooltip if tooltip is true', function () {
+            scope.openHandler();
+            expect(serviceMock.open.mostRecentCall.args[1].css('position')).toEqual('absolute');
         });
     });
     

--- a/src/test/resources/library/directives/containers/ns-modal-spec.js
+++ b/src/test/resources/library/directives/containers/ns-modal-spec.js
@@ -72,6 +72,27 @@ describe('nsModal directive', function () {
         });
     });
 
+    describe('isTooltip', function () {
+        var scope,
+            template;
+
+        beforeEach(function () {
+            scope = $rootScope.$new();
+            template = angular.element('<ns-modal open="openHandler" close="closeHandler" is-tooltip="true">myModal</ns-modal>') 
+            $compile(template)(scope);
+            scope.$apply();
+        });
+
+        iit('should position the tooltip', function () {
+            spyOn(element, 'css');
+            scope.openHandler();
+            expect(element.css).toHaveBeenCalledWith('position', 'absolute');
+            expect(element.css).toHaveBeenCalledWith('top', jasmine.any(Number));
+            expect(element.css).toHaveBeenCalledWith('left', jasmine.any(Number));
+        });
+    });
+    
+
     describe('EVENTS', function () {
         var scope,
             template;

--- a/src/test/resources/library/directives/containers/ns-modal-spec.js
+++ b/src/test/resources/library/directives/containers/ns-modal-spec.js
@@ -1,6 +1,8 @@
 describe('nsModal directive', function () {
     var $rootScope,
         $compile,
+        $controller,
+        controller,
         nsModal,
         serviceMock;
 
@@ -17,9 +19,10 @@ describe('nsModal directive', function () {
             $provide.value('nsModal', serviceMock);
         });
 
-        inject(function (_$rootScope_, _$compile_) {
+        inject(function (_$rootScope_, _$compile_, _$controller_) {
             $rootScope = _$rootScope_;
             $compile = _$compile_; 
+            $controller = _$controller_;
         });
 
         for (var name in serviceMock) {
@@ -72,23 +75,29 @@ describe('nsModal directive', function () {
         });
     });
 
-    describe('isTooltip', function () {
-        var scope,
-            template;
+    describe('nsModalCtrl#isTooltip', function () {
+        var elementSpy;
 
         beforeEach(function () {
             scope = $rootScope.$new();
-            template = angular.element('<ns-modal open="openHandler" close="closeHandler" is-tooltip="true">myModal</ns-modal>') 
-            $compile(template)(scope);
+            controller = $controller('nsModalCtrl', { $scope: scope });
             scope.$apply();
+
+            elementSpy = {
+                css: jasmine.createSpy('css spy')
+            };
         });
 
-        iit('should position the tooltip', function () {
-            spyOn(element, 'css');
-            scope.openHandler();
-            expect(element.css).toHaveBeenCalledWith('position', 'absolute');
-            expect(element.css).toHaveBeenCalledWith('top', jasmine.any(Number));
-            expect(element.css).toHaveBeenCalledWith('left', jasmine.any(Number));
+        it('should set css position, top, and left properties of the tooltip', function () {
+            controller.positionTooltip(undefined, elementSpy)
+            expect(elementSpy.css).toHaveBeenCalledWith('position', 'absolute');
+            expect(elementSpy.css).toHaveBeenCalledWith('top', undefined);
+            expect(elementSpy.css).toHaveBeenCalledWith('left', undefined);
+        });
+
+        it('should return the positioned element', function () {
+            var res = controller.positionTooltip(undefined, elementSpy);
+            expect(res).toEqual(elementSpy);
         });
     });
     


### PR DESCRIPTION
### CHANGE SUMMARY
- adding optional `isTooltip` attribute flag, which when enabled will position the modal as a tooltip (i.e. calculate the position based on the clicked element) instead of positioning via CSS
### TEST COVERAGE
- adding a test to make sure tooltip position calculation happens if the `isTooltip` attribute is set to true
### TO DO
- tooltip position calculation is (relatively) hard-coded, in terms of where the tooltip is placed in relation to the specified element. I'd like to be able to customize this on the fly, just haven't done it yet.
